### PR TITLE
Share Not tag_aliases Among Different Users

### DIFF
--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -11,13 +11,15 @@ import System.Environment (getArgs)
 import System.Exit (ExitCode(..), exitWith)
 import System.IO
 import System.Process (waitForProcess)
+import System.Posix.User (getLoginName)
 
 runCommand :: Command -> IO ExitCode
 runCommand command = do
   (hStdout, hStderr, proc) <- runCommandWithoutBlocking command
   hSetBinaryMode hStdout True
 
-  writeHandle <- openFile "/tmp/tag_aliases" WriteMode
+  userName <- getLoginName
+  writeHandle <- openFile ("/tmp/tag_aliases_" ++ userName) WriteMode
   processFileHandle (handleOutputLine writeHandle) hStdout Nothing
 
   exitCode <- waitForProcess proc

--- a/tag.cabal
+++ b/tag.cabal
@@ -38,6 +38,7 @@ executable tag
                      , process == 1.4.3.0
                      , regex-pcre == 0.94.4
                      , tag
+                     , unix >= 2.7 && < 3
 
 test-suite tag-test
   type:                exitcode-stdio-1.0


### PR DESCRIPTION
_Problem_

tag stops working when you switch users on the same machine because the
second user doesn't have write permission to the alias file.

_Solution_

Postfix the alias file with user name.