### PR TITLE
Unbreak my neovim

### DIFF
--- a/src/Vim.hs
+++ b/src/Vim.hs
@@ -3,6 +3,6 @@ module Vim where
 import EditorPosition
 
 vimEditCommand :: String -> (Line, Column) -> String
-vimEditCommand path (line, column) = "vim "
+vimEditCommand path (line, column) = "$EDITOR "
   ++ "\\\"" ++ path ++ "\\\""
   ++ " \\\"+call cursor(" ++ show line ++ ", " ++ show column ++ ")\\\""


### PR DESCRIPTION
A pretty shitty fix, but it works.
$EDITOR might not be the most politically correct way to fix this,
but anyways if you're using emacs,

``` bash
sudo apt install vim
sudo apt remove --purge emacs
alias emacs=vim
```