### PR TITLE
Fix test assertion order

### DIFF
--- a/test/AgTests.hs
+++ b/test/AgTests.hs
@@ -8,20 +8,20 @@ import Test.HUnit
 testAgCommand :: Test
 testAgCommand = TestCase $
   assertEqual "Passed arguments are appended to Command"
-  (agCommand ["foo"])
   (Command "ag" ["--group", "--color", "--column", "foo"])
+  (agCommand ["foo"])
 
 testParsingAgFilePathOutput :: String -> Test
 testParsingAgFilePathOutput line = TestCase $
   assertEqual "Test ag filepath line is parsed correctly"
-  (getOutputType line)
   (FilePath "LICENSE")
+  (getOutputType line)
 
 testParsingAgSearchLine :: String -> Test
 testParsingAgSearchLine line = TestCase $
   assertEqual "Test ag search output line is parsed correctly"
-  (getOutputType line)
   (Location 4 2)
+  (getOutputType line)
 
 allAgTests :: IO [Test]
 allAgTests = do

--- a/test/RgTests.hs
+++ b/test/RgTests.hs
@@ -8,20 +8,20 @@ import Test.HUnit
 testRgCommand :: Test
 testRgCommand = TestCase $
   assertEqual "Passed arguments are appended to Command"
-  (rgCommand ["foo"])
   (Command "rg" ["--heading", "--color", "always", "--column", "foo"])
+  (rgCommand ["foo"])
 
 testParsingRgFilePathOutput :: String -> Test
 testParsingRgFilePathOutput line = TestCase $
   assertEqual "Test rg filepath line is parsed correctly"
-  (getOutputType line)
   (FilePath "LICENSE")
+  (getOutputType line)
 
 testParsingRgSearchLine :: String -> Test
 testParsingRgSearchLine line = TestCase $
   assertEqual "Test rg search output line is parsed correctly"
-  (getOutputType line)
   (Location 4 2)
+  (getOutputType line)
 
 allRgTests :: IO [Test]
 allRgTests = do


### PR DESCRIPTION
[assertEqual][1] takes the expected value as the 2nd argument. You can
see the consequence of this by making a test fail and observe the error
message (after the fix).

```
Test rg search output line is parsed correctly
expected: Location 4 1
 but got: Location 4 2
```

[1]: http://hackage.haskell.org/package/HUnit-1.6.0.0/docs/Test-HUnit-Base.html#v:assertEqual