### PR TITLE
Improve shell compatibility

### DIFF
--- a/src/Vim.hs
+++ b/src/Vim.hs
@@ -3,6 +3,6 @@ module Vim where
 import EditorPosition
 
 vimEditCommand :: String -> (Line, Column) -> String
-vimEditCommand path (line, column) = "$EDITOR "
+vimEditCommand path (line, column) = "eval '$EDITOR "
   ++ "\\\"" ++ path ++ "\\\""
-  ++ " \\\"+call cursor(" ++ show line ++ ", " ++ show column ++ ")\\\""
+  ++ " \\\"+call cursor(" ++ show line ++ ", " ++ show column ++ ")\\\"'"


### PR DESCRIPTION
https://github.com/keith/tag/pull/8 made tag stop working for fish because
environment variables can't be in place of executables in fish. Using
`eval '$EDITOR \"PATH\" \"+call cursor(LINE, COLUMN)\"'` seems to work
across fish/zsh/bash.