### PR TITLE
Handle piping to and from tag

### DIFF
--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -1,17 +1,17 @@
 module Main where
 
 import Command
-import Commands (commandFromString)
-import CustomIO (processFileHandle)
+import Commands (commandFromArguments, commandFromString)
+import CustomIO (isRunningThroughPipes, processFileHandle)
 import Data.Maybe (listToMaybe)
 import EitherUtils (maybeToEither)
 import Parser (handleOutputLine)
-import RunCommand (runCommandWithoutBlocking)
+import RunCommand (createProcessForCommand, runCommandWithoutBlocking)
 import System.Environment (getArgs)
 import System.Exit (ExitCode(..), exitWith)
 import System.IO
-import System.Process (waitForProcess)
 import System.Posix.User (getLoginName)
+import System.Process (waitForProcess)
 
 runCommand :: Command -> IO ExitCode
 runCommand command = do
@@ -31,13 +31,24 @@ runCommand command = do
 
   return exitCode
 
-main :: IO ExitCode
-main = do
-  args <- getArgs
-
+runFilterCommand :: [String] -> IO ExitCode
+runFilterCommand args = do
   let commandOrError = maybeToEither
                        "No argument passed\n\nUsage: tag [ag|rg] ARGS"
                        (listToMaybe args) >>= commandFromString
   case commandOrError of
     Left string -> hPutStrLn stderr string >> exitWith (ExitFailure 1)
     Right command -> runCommand $ command $ tail args
+
+runPassthroughCommand :: [String] -> IO ExitCode
+runPassthroughCommand args =
+  createProcessForCommand (commandFromArguments args, stdin, stdout, stderr)
+  >>= waitForProcess
+
+main :: IO ExitCode
+main = do
+  args <- getArgs
+  isPiped <- isRunningThroughPipes
+  if isPiped
+    then runPassthroughCommand args
+    else runFilterCommand args

--- a/src/Commands.hs
+++ b/src/Commands.hs
@@ -4,6 +4,9 @@ import Ag (agCommand)
 import Command
 import Rg (rgCommand)
 
+commandFromArguments :: [String] -> Command
+commandFromArguments args = Command (head args) (tail args)
+
 commandFromString :: String -> Either String ([String] -> Command)
 commandFromString string
     | string == "ag" = Right agCommand

--- a/src/CustomIO.hs
+++ b/src/CustomIO.hs
@@ -1,6 +1,13 @@
 module CustomIO where
 
-import System.IO (Handle, hIsEOF, hGetLine)
+import System.IO (Handle, hIsEOF, hIsTerminalDevice, hGetLine, stdin, stdout)
+
+-- Check if the current process is being piped to or from
+isRunningThroughPipes :: IO Bool
+isRunningThroughPipes = do
+  isStdinTerminal <- hIsTerminalDevice stdin
+  isStdOutTerminal <- hIsTerminalDevice stdout
+  return $ not isStdinTerminal || not isStdOutTerminal
 
 -- This function takes a function, a file handle, and a piece of context, and
 -- incrementally reads the file. With each line it passes the string to the

--- a/src/RunCommand.hs
+++ b/src/RunCommand.hs
@@ -21,3 +21,18 @@ runCommandWithoutBlocking (Command exec args) = do
                                ((,) <$> mout <*> merr)
 
   return (hout, herr, process)
+
+-- This function takes a Command, and file handles to stdin, stdout, and stderr
+-- and executes the command, reusing the file handles for the process. This
+-- gives the child process complete control over how the data is read and
+-- written to these Handles.
+createProcessForCommand :: (Command, Handle, Handle, Handle) -> IO ProcessHandle
+createProcessForCommand (Command exec args, stdin, stdout, stderr) = do
+  (_, _, _, process) <-
+    createProcess (proc exec args){
+        std_in = UseHandle stdin
+      , std_out = UseHandle stdout
+      , std_err = UseHandle stderr
+    }
+
+  return process


### PR DESCRIPTION
Previously if you piped the output of tag to a file, it would not
correctly be reformatted by ag or rg. This meant you would end up with
output that wasn't parseable on a single line, and had color codes, even
though they wouldn't particularly be handled. Now we check to see if
either stdin or stdout is not a terminal, and we pass through the
command directly, without any processing.