### PR TITLE
Editor compatibility

### DIFF
--- a/src/Vim.hs
+++ b/src/Vim.hs
@@ -5,4 +5,4 @@ import EditorPosition
 vimEditCommand :: String -> (Line, Column) -> String
 vimEditCommand path (line, column) = "eval '$EDITOR "
   ++ "\\\"" ++ path ++ "\\\""
-  ++ " \\\"+call cursor(" ++ show line ++ ", " ++ show column ++ ")\\\"'"
+  ++ " \\\"+" ++ show line ++ "\\\"'"


### PR DESCRIPTION
Both Vim, Emacs and Kakoune respect this format to edit file:line.
The downside of this approach is that it doesn't put the cursor on
the right position (column).

Opening this just for the idea.
The alternative approach is to string switch on $EDITOR and handle
each one separately in a 'call()' fashion.