### PR TITLE
Remove unnecessary input / output args

### DIFF
--- a/bin/Main.hs
+++ b/bin/Main.hs
@@ -62,8 +62,7 @@ runFilterCommand aliasFile command = do
 
 runPassthroughCommand :: Command -> IO ExitCode
 runPassthroughCommand command =
-  createProcessForCommand (command, stdin, stdout, stderr)
-  >>= waitForProcess
+  createProcessForCommand command >>= waitForProcess
 
 main :: IO ExitCode
 main = do

--- a/src/RunCommand.hs
+++ b/src/RunCommand.hs
@@ -2,7 +2,7 @@ module RunCommand where
 
 import Command
 import Data.Maybe (fromMaybe)
-import System.IO (Handle)
+import System.IO
 import System.Process
 
 -- This function takes a Command argument, and launches a new process with the
@@ -26,8 +26,8 @@ runCommandWithoutBlocking (Command exec args) = do
 -- and executes the command, reusing the file handles for the process. This
 -- gives the child process complete control over how the data is read and
 -- written to these Handles.
-createProcessForCommand :: (Command, Handle, Handle, Handle) -> IO ProcessHandle
-createProcessForCommand (Command exec args, stdin, stdout, stderr) = do
+createProcessForCommand :: Command -> IO ProcessHandle
+createProcessForCommand (Command exec args) = do
   (_, _, _, process) <-
     createProcess (proc exec args){
         std_in = UseHandle stdin


### PR DESCRIPTION
These weren't customized so I think it's nicer to be up to the function
instead of the caller.