### PR TITLE
Fix piped commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,3 +15,4 @@ jobs:
           ghc: 8.8.4
           enable-stack: true
       - run: stack test
+      - run: ./integration-test.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,5 +14,7 @@ jobs:
         with:
           ghc: 8.8.4
           enable-stack: true
-      - run: stack test
-      - run: ./integration-test.sh
+      - name: test
+        run: |
+          stack test
+          ./integration-test.sh

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -3,5 +3,5 @@
 set -euo pipefail
 
 diff -Nur \
-  <(find . -name "*.s" | sort) \
+  <(find . -name "*.hs" | sort) \
   <(stack run -- find . -name "*.hs" | sort)

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+diff -Nur <(rg --sort path foo) <(stack run -- rg --sort path foo | cat)

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -3,5 +3,5 @@
 set -euo pipefail
 
 diff -Nur \
-  <(find . -name "*.hs" | sort) \
+  <(find . -name "*.s" | sort) \
   <(stack run -- find . -name "*.hs" | sort)

--- a/integration-test.sh
+++ b/integration-test.sh
@@ -2,4 +2,6 @@
 
 set -euo pipefail
 
-diff -Nur <(rg --sort path foo) <(stack run -- rg --sort path foo | cat)
+diff -Nur \
+  <(find . -name "*.hs" | sort) \
+  <(stack run -- find . -name "*.hs" | sort)


### PR DESCRIPTION
The issue here was using tag's Command instructors regardless of piping
or not, because of that we forced --color and others. Now we pass them
through directly again.

Fixes https://github.com/keith/tag/issues/19