### PR TITLE
Update fish shell instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ to print the file containing the first match.
 
 ```fish
 function tag
-  command tag $argv; and source /tmp/tag_aliases ^/dev/null
+  command tag $argv; and source /tmp/tag_aliases &> /dev/null
   alias ag "tag ag"
   alias fd "tag fd"
   alias find "tag find"


### PR DESCRIPTION
the `^` syntax has been deprecated and turned off in [Fish 3.3](https://fishshell.com/docs/current/relnotes.html#fish-3-3-0-released-june-28-2021). The redirect everything syntax is now `&>`.