### PR TITLE
Add Nix support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,15 @@
 on: [push]
 name: build
 jobs:
+  build-nix:
+    runs-on: ubuntu-latest
+    name: Nix
+    steps:
+    - uses: actions/checkout@v2.4.0
+    - uses: cachix/install-nix-action@v15
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
+    - run: nix-build
   build-linux:
     runs-on: ubuntu-latest
     name: Linux

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build
 compile_commands.json
 tag
 tag.tar.gz
+result

--- a/README.md
+++ b/README.md
@@ -44,12 +44,11 @@ let
       owner = "keith";
       repo = "tag";
       rev = "0.8.0";
-      sha256 = "sha256-0000000000000000000000000000000000000000000=";
+      sha256 = "132k8wh7x2y61j9j3lk646wp2dp9jakx0inc7hcbgy8li2kb03sm";
     })
     { inherit pkgs; };
 in
   # Use `tag` from here on as a derivation.
-  # you'll need to update the sha256 yourself.
 ```
 
 Manually:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,23 @@ On macOS:
 $ brew install keith/formulae/tag
 ```
 
+With Nix/NixOS:
+
+```nix
+let
+  tag = import
+    (pkgs.fetchFromGitHub {
+      owner = "keith";
+      repo = "tag";
+      rev = "0.8.0";
+      sha256 = "sha256-0000000000000000000000000000000000000000000=";
+    })
+    { inherit pkgs; };
+in
+  # Use `tag` from here on as a derivation.
+  # you'll need to update the sha256 yourself.
+```
+
 Manually:
 
 ```sh

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,14 @@
+{ pkgs ? import <nixpkgs> {} }:
+with pkgs;
+stdenv.mkDerivation rec {
+  pname = "tag";
+  version = "0.8.0";
+  src = ./.;
+  buildPhase = ''
+    ${clang}/bin/clang++ -std=c++17 -O3 tag.cpp -o tag
+  '';
+  installPhase = ''
+    mkdir -p $out/bin
+    mv tag $out/bin
+  '';
+}


### PR DESCRIPTION
Add the bare-bone stuff to make tag a Nix package.

A fancier alternative is to support Nix flake. At time of this patching,
it involves a few external dependencies and hundreds more LOC checked
into this repo. Nix flakes can consume this setup as well in `flake
= false` mode anyways.