### PR TITLE
Add support for piping file names directly

### DIFF
--- a/integration-test.sh
+++ b/integration-test.sh
@@ -6,6 +6,11 @@ diff -Nur \
   <(find . | sort) \
   <(./build/tag find . | sort)
 
+if ./build/tag </dev/null 2>/dev/null; then
+  echo "error: tag without arguments should fail without piped input" >&2
+  exit 1
+fi
+
 tmpfile=$(mktemp)
 expected=$(mktemp)
 cat <<EOF > "$expected"
@@ -18,6 +23,17 @@ SKIP_PIPE_FILTERING=true SHELL=zsh ./build/tag --alias-file "$tmpfile" find . -n
 diff -Nur "$expected" "$tmpfile"
 SKIP_PIPE_FILTERING=true SHELL=zsh ./build/tag find . -name "*.md"
 diff -Nur "$expected" /tmp/tag_aliases
+
+cat <<'EOF' > "$expected"
+alias eall="eval '$EDITOR -q \"/tmp/tag_qf\"'"
+alias e1="eval '$EDITOR \"README.md\"'"
+alias -g f1="README.md"
+alias e2="eval '$EDITOR \"tag.cpp\"'"
+alias -g f2="tag.cpp"
+EOF
+
+printf 'README.md\ntag.cpp\n' | SHELL=zsh ./build/tag --alias-file "$tmpfile" > /dev/null
+diff -Nur "$expected" "$tmpfile"
 
 SKIP_PIPE_FILTERING=true SHELL=zsh ./build/tag --alias-file "$tmpfile" ls LICENSE README.md
 cat <<EOF > "$expected"
@@ -44,7 +60,7 @@ alias e4="eval '\$EDITOR \"README.md\" \"+call cursor(16, 63)\"'"
 alias -g f4="README.md"
 alias e5="eval '\$EDITOR \"README.md\" \"+call cursor(17, 26)\"'"
 alias -g f5="README.md"
-alias e6="eval '\$EDITOR \"integration-test.sh\" \"+call cursor(52, 53)\"'"
+alias e6="eval '\$EDITOR \"integration-test.sh\" \"+call cursor(68, 53)\"'"
 alias -g f6="integration-test.sh"
 EOF
 

--- a/tag.cpp
+++ b/tag.cpp
@@ -263,6 +263,42 @@ runAndWriteFile(const Command cmd, std::string outputFile, std::string args) {
   });
 }
 
+[[nodiscard]] static int runStdinAndWriteFile(std::string outputFile) {
+  int aliasIndex = 1;
+  std::ofstream os(outputFile);
+  std::ofstream qfOS(QF_FILE);
+
+  os << aliasForCommand("all", vimEditCommand(QF_FILE, std::nullopt, "-q "))
+     << std::endl;
+
+  std::string line;
+  while (std::getline(std::cin, line)) {
+    std::string path = stripAnsi(line);
+    rstrip(path);
+    if (path.empty()) {
+      std::cout << line << std::endl;
+      continue;
+    }
+
+    qfOS << formatQFLine(path, 1, 1, "") << std::endl;
+    printAliasedLine(aliasIndex, line + "\n");
+
+    let editCmd = vimEditCommand(path, std::nullopt);
+    os << aliasForCommand(aliasIndex, editCmd) << std::endl;
+    if (isZSH()) {
+      os << globalAliasForCommand(aliasIndex, path) << std::endl;
+    }
+
+    ++aliasIndex;
+    os.flush();
+  }
+
+  if (std::cin.bad())
+    return 1;
+
+  return 0;
+}
+
 [[noreturn]] static void helpAndExit() {
   std::stringstream cmdNames;
   cmdNames << "[";
@@ -288,13 +324,19 @@ runAndWriteFile(const Command cmd, std::string outputFile, std::string args) {
 
 int main(int argc, char *argv[]) {
   std::deque<std::string> arguments(argv + 1, argv + argc);
-  if (arguments.empty())
-    helpAndExit();
 
   std::string argFile("/tmp/tag_aliases");
-  if (arguments.front() == "--alias-file") {
+  if (!arguments.empty() && arguments.front() == "--alias-file") {
     arguments.pop_front();
     argFile = popFirst(arguments);
+  }
+
+  if (arguments.empty()) {
+    if (!isatty(fileno(stdin)) &&
+        std::cin.peek() != std::char_traits<char>::eof())
+      return runStdinAndWriteFile(argFile);
+
+    helpAndExit();
   }
 
   let cmdString = popFirst(arguments);


### PR DESCRIPTION
This is useful for complex `fd` commands where you pipe the output
through some greps or something. Now you can do:

```
fd foo | grep -v something | tag
```
